### PR TITLE
Update pfb_dnsbl.safesearch.conf

### DIFF
--- a/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf
+++ b/net/pfSense-pkg-pfBlockerNG-devel/files/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf
@@ -1,5 +1,5 @@
-local-data: "www.duckduckgo.com A 54.229.105.151"
-local-data: "duckduckgo.com A 54.229.105.151"
+local-data: "www.duckduckgo.com A 40.114.177.246"
+local-data: "duckduckgo.com A 540.114.177.246"
 local-data: "pixabay.com A 104.18.141.87"
 local-data: "yandex.ru A 213.180.193.56"
 local-data: "yandex.ua A 213.180.193.56"


### PR DESCRIPTION
New ip for safe.duckduckgo.com the old ip does not work as of sept 5th 2020